### PR TITLE
fix: frappe.app missing imports

### DIFF
--- a/renovation_core/app.py
+++ b/renovation_core/app.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 import frappe
-from frappe.app import (NotFound, after_request,
+from frappe.app import (NotFound, after_request, _site, _sites_path,
                         get_site_name, handle_exception, local_manager,
                         make_form_dict)
 from frappe.middlewares import StaticDataMiddleware


### PR DESCRIPTION
Frappe sites in production were failing without this