### PR TITLE
fix: Mobile number compared after being modified

### DIFF
--- a/renovation_core/utils/auth.py
+++ b/renovation_core/utils/auth.py
@@ -42,7 +42,8 @@ def generate_sms_pin():
     msg = msg + u". " + hash
   sms = send_sms([mobile], msg, success_msg=False)
   status = "fail"
-  if sms and isinstance(sms, list) and mobile in sms:
+  # Since SMS Settings might remove or add '+' character, we will check against the last 5 digits
+  if sms and isinstance(sms, list) and len(sms) == 1 and mobile[-5:] in sms[0]:
     status = "success"
   update_http_response({"status": status, "mobile": mobile})
 


### PR DESCRIPTION
Since SMS settings may modify the number by either adding or removing a `+`, the check for the return of SMS (list) against the request's mobile number, it will be false. That's why we can check the number partially (last 5 digits).