### PR TITLE
fix: Null Exception

### DIFF
--- a/renovation_core/utils/logging.py
+++ b/renovation_core/utils/logging.py
@@ -146,6 +146,10 @@ def update_cache():
                                       ["log_all_requests", "always_log_4xx_request",
                                        "limit_logging_to_apps"],
                                       as_dict=1)
+  if not logging_settings:
+    # there are some rare conditions when this can be null
+    # maybe when frappe errored out before init db?
+    logging_settings = frappe._dict()
   logging_settings.log_all_requests = cint(
       logging_settings.get("log_all_requests", 0))
   logging_settings.always_log_4xx_request = cint(


### PR DESCRIPTION
This particular bug was noticed on Sezer

```
[2020-06-02 02:27:15 +0000] [3816] [ERROR] Error handling request /
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 176, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/werkzeug/local.py", line 231, in application
    return ClosingIterator(app(environ, start_response), self.cleanup)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/werkzeug/wrappers/base_request.py", line 237, in application
    resp = f(*args[:-2] + (request,))
  File "/home/frappe/frappe-bench/apps/renovation_core/renovation_core/app.py", line 74, in application
    log_request(response)
  File "/home/frappe/frappe-bench/apps/renovation_core/renovation_core/utils/logging.py", line 73, in log_request
    if not logging_enabled(response) or ignore_cmd():
  File "/home/frappe/frappe-bench/apps/renovation_core/renovation_core/utils/logging.py", line 128, in logging_enabled
    update_cache()
  File "/home/frappe/frappe-bench/apps/renovation_core/renovation_core/utils/logging.py", line 150, in update_cache
    logging_settings.get("log_all_requests", 0))
AttributeError: 'NoneType' object has no attribute 'get'
```