### PR TITLE
feat: OAuth2 using Google & Apple

### DIFF
--- a/renovation_core/hooks.py
+++ b/renovation_core/hooks.py
@@ -139,23 +139,23 @@ scheduler_events = {
     ]
 }
 
-# scheduler_events = {
-# 	"all": [
-# 		"renovation_core.tasks.all"
-# 	],
-# 	"daily": [
-# 		"renovation_core.tasks.daily"
-# 	],
-# 	"hourly": [
-# 		"renovation_core.tasks.hourly"
-# 	],
-# 	"weekly": [
-# 		"renovation_core.tasks.weekly"
-# 	]
-# 	"monthly": [
-# 		"renovation_core.tasks.monthly"
-# 	]
-# }
+scheduler_events = {
+    # 	"all": [
+    # 		"renovation_core.tasks.all"
+    # 	],
+    # 	"daily": [
+    # 		"renovation_core.tasks.daily"
+    # 	],
+    # 	"hourly": [
+    # 		"renovation_core.tasks.hourly"
+    # 	],
+    # 	"weekly": [
+    # 		"renovation_core.tasks.weekly"
+    # 	]
+    "monthly": [
+        "renovation_core.tasks.monthly"
+    ]
+}
 
 # Testing
 # -------

--- a/renovation_core/hooks.py
+++ b/renovation_core/hooks.py
@@ -153,7 +153,7 @@ scheduler_events = {
     # 		"renovation_core.tasks.weekly"
     # 	]
     "monthly": [
-        "renovation_core.tasks.monthly"
+        "renovation_core.tasks.generate_apple_client_secret"
     ]
 }
 

--- a/renovation_core/oauth.py
+++ b/renovation_core/oauth.py
@@ -19,6 +19,19 @@ def login_via_google(code, state=None, login=True, use_jwt=False):
   return login_via_oauth2('google', code=code, state=state, decoder=decoder_compat, login=login)
 
 
+def get_info_via_google(code):
+  """
+  # Sometimes we only need the id without logging in or creating a user.
+  This function will return the details of google response (email, id, name, etc...)
+  :param code: The auth code from Google's Auth server
+  :return:
+  """
+  data = get_info_via_oauth("google", code, decoder=decoder_compat)
+  if isinstance(data, string_types):
+    data = json.loads(data)
+  return data
+
+
 def login_via_oauth2(provider, code, state, decoder=None, login=True):
   info = get_info_via_oauth(provider, code, decoder)
   return login_oauth_user(info, provider=provider, state=state, login=login)

--- a/renovation_core/oauth.py
+++ b/renovation_core/oauth.py
@@ -1,0 +1,66 @@
+import base64
+import json
+
+import frappe
+from frappe import _
+from frappe.integrations.oauth2_logins import decoder_compat
+from frappe.utils.oauth import get_oauth2_authorize_url, get_email, update_oauth_user, SignupDisabledError, \
+  get_info_via_oauth
+from six import string_types
+
+
+@frappe.whitelist(allow_guest=True)
+def get_oauth_url(provider: str, redirect_to: str) -> str:
+  return get_oauth2_authorize_url(provider, redirect_to)
+
+
+@frappe.whitelist(allow_guest=True)
+def login_via_google(code, state=None):
+  return login_via_oauth2('google', code=code, state=state, decoder=decoder_compat)
+
+
+def login_via_oauth2(provider, code, state, decoder=None):
+  info = get_info_via_oauth(provider, code, decoder)
+  return login_oauth_user(info, provider=provider, state=state)
+
+
+def login_oauth_user(data=None, provider=None, state=None):
+  if isinstance(data, string_types):
+    data = json.loads(data)
+
+  if isinstance(state, string_types):
+    state = base64.b64decode(state)
+    state = json.loads(state.decode("utf-8"))
+
+  user = get_email(data)
+
+  if not user:
+    frappe.throw(_("Please ensure that your profile has an email address"))
+
+  try:
+    if update_oauth_user(user, data, provider) is False:
+      return
+
+  except SignupDisabledError:
+    return frappe.throw("Signup is Disabled", "Sorry. Signup from Website is disabled.")
+
+  frappe.local.login_manager.user = user
+  frappe.local.login_manager.post_login()
+
+  # because of a GET request!
+  frappe.db.commit()
+
+  if state:
+    redirect_to = state.get("redirect_to", None)
+    redirect_post_login(desk_user=frappe.local.response.get('message') == 'Logged In', redirect_to=redirect_to)
+
+
+def redirect_post_login(desk_user, redirect_to=None):
+  # redirect!
+  frappe.local.response["type"] = "redirect"
+
+  if not redirect_to:
+    # the #desktop is added to prevent a facebook redirect bug
+    redirect_to = "/desk#desktop" if desk_user else "/me"
+
+  frappe.local.response["location"] = redirect_to

--- a/renovation_core/oauth.py
+++ b/renovation_core/oauth.py
@@ -57,7 +57,6 @@ def get_info_via_google(code):
   return data
 
 
-@frappe.whitelist(allow_guest=True)
 def get_info_via_apple(code, option=None):
   """
   # Sometimes we only need the id without logging in or creating a user.

--- a/renovation_core/oauth.py
+++ b/renovation_core/oauth.py
@@ -3,8 +3,8 @@ import json
 import frappe
 from frappe import _
 from frappe.integrations.oauth2_logins import decoder_compat
-from frappe.utils.oauth import get_oauth2_authorize_url, get_email, update_oauth_user, SignupDisabledError, \
-  get_info_via_oauth
+from frappe.utils.oauth import get_info_via_oauth, get_oauth2_authorize_url, get_email, SignupDisabledError, \
+  update_oauth_user
 from six import string_types
 
 
@@ -22,7 +22,7 @@ def login_via_google(code, state=None, login=True, use_jwt=False):
 @frappe.whitelist(allow_guest=True)
 def login_via_apple(code, state=None, login=True, use_jwt=False):
   frappe.form_dict['use_jwt'] = use_jwt
-  return login_via_oauth2('apple', code=code, state=state, login=login, decoder=decoder_compat, id_token=True)
+  return login_via_oauth2_id_token('apple', code=code, state=state, login=login, decoder=decoder_compat)
 
 
 def get_info_via_google(code):
@@ -38,8 +38,13 @@ def get_info_via_google(code):
   return data
 
 
-def login_via_oauth2(provider, code, state, decoder=None, login=True, id_token=None):
-  info = get_info_via_oauth(provider, code, decoder, id_token=id_token)
+def login_via_oauth2(provider, code, state, decoder=None, login=True):
+  info = get_info_via_oauth(provider, code, decoder)
+  return login_oauth_user(info, provider=provider, state=state, login=login)
+
+
+def login_via_oauth2_id_token(provider, code, state, decoder=None, login=True):
+  info = get_info_via_oauth(provider, code, decoder, id_token=True)
   return login_oauth_user(info, provider=provider, state=state, login=login)
 
 

--- a/renovation_core/oauth.py
+++ b/renovation_core/oauth.py
@@ -19,6 +19,12 @@ def login_via_google(code, state=None, login=True, use_jwt=False):
   return login_via_oauth2('google', code=code, state=state, decoder=decoder_compat, login=login)
 
 
+@frappe.whitelist(allow_guest=True)
+def login_via_apple(code, state=None, login=True, use_jwt=False):
+  frappe.form_dict['use_jwt'] = use_jwt
+  return login_via_oauth2('apple', code=code, state=state, login=login, decoder=decoder_compat, id_token=True)
+
+
 def get_info_via_google(code):
   """
   # Sometimes we only need the id without logging in or creating a user.
@@ -32,8 +38,8 @@ def get_info_via_google(code):
   return data
 
 
-def login_via_oauth2(provider, code, state, decoder=None, login=True):
-  info = get_info_via_oauth(provider, code, decoder)
+def login_via_oauth2(provider, code, state, decoder=None, login=True, id_token=None):
+  info = get_info_via_oauth(provider, code, decoder, id_token=id_token)
   return login_oauth_user(info, provider=provider, state=state, login=login)
 
 

--- a/renovation_core/oauth.py
+++ b/renovation_core/oauth.py
@@ -57,6 +57,31 @@ def get_info_via_google(code):
   return data
 
 
+@frappe.whitelist(allow_guest=True)
+def get_info_via_apple(code, option=None):
+  """
+  # Sometimes we only need the id without logging in or creating a user.
+  This function will return the details of google response (email, id, name, etc...)
+  :param code: The auth code from Apple's Auth server
+  :param option: The platform (native | web | android)
+  :return:
+  """
+
+  redirect_url = None
+  if option == 'web':
+    keys = frappe.conf.get('apple_login_web')
+    redirect_url = keys.get('web_url')
+  elif option == 'android':
+    keys = frappe.conf.get('apple_login_android')
+    redirect_url = keys.get('android_url')
+
+  data = get_info_via_oauth("apple", code, decoder=decoder_compat, id_token=True, option=option,
+                            redirect_url=redirect_url)
+  if isinstance(data, string_types):
+    data = json.loads(data)
+  return data
+
+
 def login_via_oauth2(provider, code, state, decoder=None, login=True):
   info = get_info_via_oauth(provider, code, decoder)
   return login_oauth_user(info, provider=provider, state=state, login=login)

--- a/renovation_core/tasks.py
+++ b/renovation_core/tasks.py
@@ -1,0 +1,54 @@
+import json
+import subprocess
+
+import frappe
+from datetime import datetime, timedelta
+import jwt
+
+
+def generate_apple_client_secret():
+  apple_keys = frappe.conf.get('apple_keys')
+  if not apple_keys:
+    frappe.log_error("Please set the apple keys in common_site_config")
+    return
+
+  headers = {
+      "kid": apple_keys.get("kid")
+  }
+
+  # Common payload details for all platforms
+  payload = {
+      "iss": apple_keys.get("iss"),
+      "iat": datetime.timestamp(datetime.now()),
+      "exp": datetime.timestamp(datetime.now() + timedelta(days=180)),
+      "aud": "https://appleid.apple.com"
+  }
+
+  native_keys = frappe.conf.get('apple_login_native')
+
+  native_payload = {**payload, "sub": native_keys.get('client_id')}
+
+  web_keys = frappe.conf.get('apple_login_web')
+  android_keys = frappe.conf.get('apple_login_android')
+
+  web_payload = {**payload, "sub": web_keys.get('client_id')}
+
+  native_client_secret = jwt.encode(native_payload, apple_keys.get('private_key'), algorithm='ES256',
+                                    headers=headers).decode('utf-8')
+
+  web_client_secret = jwt.encode(web_payload, apple_keys.get('private_key'), algorithm='ES256', headers=headers).decode(
+      'utf-8')
+
+  native_keys['client_secret'] = native_client_secret
+
+  # Since web and Android are considered non-native to Apple, and they have the same client ID they will have the same
+  # client secret
+  web_keys['client_secret'] = web_client_secret
+  android_keys['client_secret'] = web_client_secret
+
+  # Finally update the file `common_site_config.json`
+  subprocess.check_output(["bench", "set-config", "apple_login_native", json.dumps(native_keys), '--as-dict', '-g'],
+                          cwd="..")
+  subprocess.check_output(["bench", "set-config", "apple_login_web", json.dumps(web_keys), '--as-dict', '-g'], cwd="..")
+  subprocess.check_output(["bench", "set-config", "apple_login_android", json.dumps(android_keys), '--as-dict', '-g'],
+                          cwd="..")


### PR DESCRIPTION
Introduction of the ability to login and/or create a user using Google.

- [x] Create user on login via Google
- [x] Login through Google Authorization code (Cookies)
- [x] Login through Google Authorization code (JWT)
- [x] Create user on login via Apple
- [x] Login through Apple Authorization code (Cookies)
- [x] Login through Apple Authorization code (JWT)
- [x] Handle Native vs. Web access tokens for Apple
- [x] Variable Redirect URL (Specifically for Apple)
- [x] Generate Client Secret (Specifically for Apple)
- [ ] Documentation (Deffered)


### Apple Sign In Variables
Below are the fields required in the root `common_site_config.json` for Signing in with Apple

"apple_login_native":{
   "client_id": "......",
   "client_secret":"......"
 },
 "apple_login_web":{
  "client_id": "......",
  "client_secret":"......",
  "web_url":"https://example.com"
},
"apple_login_android":{
  "client_id": "......",
  "client_secret":"......",
  "android_url": "<site>/api/method/renovation_core.oauth.redirect_apple_login_to_android",
  "android_package_id":"com.example.com"
},
"apple_keys": {
  "iss": "......",
  "kid": "......",
  "private_key": "-----BEGIN PRIVATE KEY-----......-----END PRIVATE KEY-----"
 }
