### PR TITLE
feat: Guest Chat User

### DIFF
--- a/renovation_core/renovation_core/doctype/guest_chat_user/guest_chat_user.js
+++ b/renovation_core/renovation_core/doctype/guest_chat_user/guest_chat_user.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2020, LEAM Technology System and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Guest Chat User', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/renovation_core/renovation_core/doctype/guest_chat_user/guest_chat_user.json
+++ b/renovation_core/renovation_core/doctype/guest_chat_user/guest_chat_user.json
@@ -1,0 +1,64 @@
+{
+ "autoname": "field:token",
+ "creation": "2020-08-06 14:15:42.740016",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "token",
+  "guest_name",
+  "email",
+  "mobile_no"
+ ],
+ "fields": [
+  {
+   "fieldname": "token",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Token",
+   "options": "Chat Token",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "guest_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Guest Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "label": "Email"
+  },
+  {
+   "fieldname": "mobile_no",
+   "fieldtype": "Data",
+   "label": "Mobile No"
+  }
+ ],
+ "modified": "2020-08-06 14:15:42.740016",
+ "modified_by": "Administrator",
+ "module": "Renovation Core",
+ "name": "Guest Chat User",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/renovation_core/renovation_core/doctype/guest_chat_user/guest_chat_user.py
+++ b/renovation_core/renovation_core/doctype/guest_chat_user/guest_chat_user.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020, LEAM Technology System and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class GuestChatUser(Document):
+	pass

--- a/renovation_core/renovation_core/doctype/guest_chat_user/test_guest_chat_user.py
+++ b/renovation_core/renovation_core/doctype/guest_chat_user/test_guest_chat_user.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020, LEAM Technology System and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+# import frappe
+import unittest
+
+class TestGuestChatUser(unittest.TestCase):
+	pass

--- a/renovation_core/utils/chats.py
+++ b/renovation_core/utils/chats.py
@@ -1,0 +1,23 @@
+import frappe
+
+@frappe.whitelist(allow_guest=True)
+def get_guest_token(guest_name=None, email=None, mobile_no=None):
+  """
+  Creates a `Guest Chat User` document instance to store the details of the Guest
+  who is about to start with the admins. Providing the details are completely optional.
+  :param guest_name: The name of the Guest
+  :param email: The email of the Guest
+  :param mobile_no: The mobile_no of the guest
+  """
+  from frappe.chat.website import token
+  t = token()
+
+  if guest_name:
+    d = frappe.get_doc(frappe._dict(
+      doctype="Guest Chat User",
+      token=t,
+      guest_name=guest_name,
+      email=email,
+      mobile_no=mobile_no
+    )).insert(ignore_permissions=True)
+  return t


### PR DESCRIPTION
`Chat Token` is a frappe doctype used for chatting with Guest (non-logged) users.
`Guest Chat User` extends `Chat Token` with more fields like name, email, mobile_no.
Took the doctype approach instead of CustomField on ChatToken as suggested by @MalikZu 

The endpoint `renovation_core.utils.chats.get_guest_token` creates both Chat Token and Guest Chat User doc.