### PR TITLE
fix: pwd-reset bug

### DIFF
--- a/renovation_core/utils/forgot_pwd.py
+++ b/renovation_core/utils/forgot_pwd.py
@@ -116,7 +116,8 @@ def update_password(reset_token, new_password):
       updated=0, reason="weak-password"
     )
 
-  update_password(user.name, new_password)
+  from frappe.utils.password import update_password as _update_password
+  _update_password(user.name, new_password)
   frappe.db.set_value("User", user.name, "reset_password_key", "")
   return frappe._dict(
     updated=1


### PR DESCRIPTION
a function with `update_password` exists in the same py module.
To actually update the password, the `update_password` in `frappe.utils.password` has to be used,