### PR TITLE
fix: Duplicate RDocfields on migration

### DIFF
--- a/renovation_core/renovation_core/doctype/renovation_docfield/renovation_docfield.py
+++ b/renovation_core/renovation_core/doctype/renovation_docfield/renovation_docfield.py
@@ -109,7 +109,9 @@ def add_all_reqd_table_fields(doctypes=None):
             "p_doctype": doctype,
             "reference_id": field[1]
         })
-        doc.insert()
+        doc.autoname()
+        if not frappe.db.exists(doc.doctype, doc.name):
+          doc.insert()
     frappe.db.commit()
 
 


### PR DESCRIPTION
This will fix the error that we get when installing renovation_core on frappe-v13-beta