### PR TITLE
tests: Generate fixtures from the command line

### DIFF
--- a/renovation_core/tests/__init__.py
+++ b/renovation_core/tests/__init__.py
@@ -1,0 +1,4 @@
+import frappe
+
+def init_site():
+  print("init core-py-tests")

--- a/renovation_core/tests/core_dart.py
+++ b/renovation_core/tests/core_dart.py
@@ -1,0 +1,4 @@
+import frappe
+
+def init_site():
+  print("init core-dart-tests")

--- a/renovation_core/tests/core_ts.py
+++ b/renovation_core/tests/core_ts.py
@@ -89,7 +89,8 @@ def create_users():
         new_password="test@test",
         first_name="Test User",
         quick_login_pin="1234",
-        send_welcome_email=0
+        send_welcome_email=0,
+        roles=[{"role": "Website Manager"}]
     )).insert()
 
 

--- a/renovation_core/tests/core_ts.py
+++ b/renovation_core/tests/core_ts.py
@@ -1,10 +1,11 @@
 import frappe
+from frappe.utils import cint
 
 
 def init_site():
   print("Initializing site for core-ts tests")
   # Lets check if setup_complete, else lets do it first
-  if not frappe.db.get_value('System Settings', 'System Settings', 'setup_complete'):
+  if not cint(frappe.db.get_value('System Settings', 'System Settings', 'setup_complete')):
     from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
     setup_complete({
         "language": "English", "country": "United Arab Emirates", "timezone": "Asia/Dubai", "currency": "AED", "full_name": "Example Admin",
@@ -14,6 +15,7 @@ def init_site():
   create_users()
   create_dashboards()
   create_reports()
+  create_test_doctype()
   print("Done!")
   print("NB: Please create a secondary site for ENV: CORE_TS_HOST_URL_SECONDARY")
 
@@ -84,3 +86,48 @@ def create_users():
         quick_login_pin="1234",
         send_welcome_email=0
     )).insert()
+
+
+def create_test_doctype():
+  if frappe.db.exists("DocType", "TEST DOCTYPE"):
+    return
+
+  # Child Doctype
+  frappe.get_doc(frappe._dict(
+      doctype="DocType",
+      __newname="TEST DOCTYPE ITEM",
+      module="Renovation Core",
+      custom=1,
+      editable_grid=1,
+      istable=1,
+      fields=[
+          frappe._dict(label="Title", fieldtype="Data", fieldname="title", in_list_view=1)
+      ]
+  )).insert()
+
+  doc = frappe.get_doc(frappe._dict(
+      doctype="DocType",
+      __newname="TEST DOCTYPE",
+      module="Renovation Core",
+      custom=1,
+      allow_rename=1,
+      allow_import=1,
+      track_changes=1,
+      autoname="field:title",
+      is_submittable=1,
+      fields=[
+          frappe._dict(fieldtype="Data", fieldname="title",
+                       label="Document Title"),
+          frappe._dict(fieldtype="Table", fieldname="items",
+                       options="TEST DOCTYPE ITEM", label="Items")
+      ],
+      permissions=[
+          frappe._dict(
+              role="System Manager", share=1, submit=1, write=1,
+              amend=1, cancel=1, create=1, delete=1, docstatus=0,
+              email=1, export=1, permlevel=0, print=1, read=1, report=1
+          )
+      ]
+  ))
+  doc.permissions[0].set("import", 1)
+  doc.insert()

--- a/renovation_core/tests/core_ts.py
+++ b/renovation_core/tests/core_ts.py
@@ -1,0 +1,86 @@
+import frappe
+
+
+def init_site():
+  print("Initializing site for core-ts tests")
+  # Lets check if setup_complete, else lets do it first
+  if not frappe.db.get_value('System Settings', 'System Settings', 'setup_complete'):
+    from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
+    setup_complete({
+        "language": "English", "country": "United Arab Emirates", "timezone": "Asia/Dubai", "currency": "AED", "full_name": "Example Admin",
+        "email": "admin@example.com", "password": "leamadmin"
+    })
+
+  create_users()
+  create_dashboards()
+  create_reports()
+  print("Done!")
+  print("NB: Please create a secondary site for ENV: CORE_TS_HOST_URL_SECONDARY")
+
+
+def create_reports():
+  print("Creating Reports Fixtures")
+
+  if not frappe.db.exists("Report", "TEST"):
+    frappe.get_doc(frappe._dict(
+        doctype="Report",
+        report_name="TEST",
+        report_type="Report Builder",
+        ref_doctype="Note",
+        disabled=0,
+        is_standard="No",
+        json="{}"
+    )).insert()
+
+  if not frappe.db.exists("Renovation Report", "TEST"):
+    frappe.get_doc(frappe._dict(
+        doctype="Renovation Report",
+        report="TEST"
+    )).insert()
+
+
+def create_dashboards():
+  print("Creating dashboard fixtures")
+
+  if not frappe.db.exists("Renovation Dashboard", "TEST"):
+    frappe.get_doc(frappe._dict(
+        doctype="Renovation Dashboard",
+        title="TEST",
+        type="lines",
+        exc_type="cmd",
+        is_standard="No",
+        roles=[{"role": "All"}],
+    )).insert()
+
+  # make layout
+  if not frappe.db.exists("Renovation Dashboard Layout", "TEST"):
+    frappe.get_doc(frappe._dict(
+        doctype="Renovation Dashboard Layout",
+        title="TEST",
+        enabled=1,
+        can_resize_items=1,
+        can_rearrange_items=1,
+        roles=[{"role": "All"}],
+        dashboards=[{
+            "dashboard": "TEST",
+            "width": 3,
+            "height": 2
+        }]
+    )).insert()
+
+
+def create_users():
+  print("Setting up users")
+  # Set admin email
+  frappe.db.set_value("User", "Administrator", "email", "admin@example.com")
+
+  # create user
+  if not frappe.db.exists("User", "test@test.com"):
+    frappe.get_doc(frappe._dict(
+        doctype="User",
+        email="test@test.com",
+        new_password="test@test",
+        first_name="Test User",
+        quick_login_pin="1234",
+        send_welcome_email=0
+    )).insert()

--- a/renovation_core/tests/core_ts.py
+++ b/renovation_core/tests/core_ts.py
@@ -27,11 +27,16 @@ def create_reports():
     frappe.get_doc(frappe._dict(
         doctype="Report",
         report_name="TEST",
-        report_type="Report Builder",
+        report_type="Query Report",
         ref_doctype="Note",
         disabled=0,
         is_standard="No",
-        json="{}"
+        json="{}",
+        query="""SELECT
+    name AS 'Name:Data:200',
+    title AS 'Title:Data:200',
+    content AS 'Content:Data:200'
+FROM `tabNote`;"""
     )).insert()
 
   if not frappe.db.exists("Renovation Report", "TEST"):


### PR DESCRIPTION
This will add a renovation command which can be used to make fixtures for testing of `core-py`, `core-ts` & `core-dart`
I have defined the fixtures for `core-ts`. Other two remains.

```sh
$ bench --site test_site renovation init-test-site

Tests for (core-py, core-ts, core-dart): core-ts
Reinstall [y/N]: y
MySQL root password: 
Creating Database...
11.9KiB 0:00:00 [ 773MiB/s] [===========================================================>] 100%            

Installing frappe...
Updating DocTypes for frappe        : [========================================] 100%
Updating country info               : [========================================] 100%
Set Administrator password: 
Re-enter Administrator password: 

Installing renovation_core...
Updating DocTypes for renovation_core: [========================================] 100%
Supervisor config not found
Procfile updated to use renovation_core/socketio.js
You may have to restart bench to complete configuration
*** Scheduler is enabled ***
Initializing site for core-ts tests
Setting up users
Creating dashboard fixtures
Creating Reports Fixtures
Done!
NB: Please create a secondary site for ENV: CORE_TS_HOST_URL_SECONDARY
```