### PR TITLE
fix: RenovationDashboard is_standard flag

### DIFF
--- a/renovation_core/renovation_dashboard_def/doctype/renovation_dashboard/renovation_dashboard.py
+++ b/renovation_core/renovation_dashboard_def/doctype/renovation_dashboard/renovation_dashboard.py
@@ -18,7 +18,9 @@ class RenovationDashboard(Document):
       self.name = self.title
 
   def on_update(self):
-    path = export_module_json(self, self.is_standard, self.module)
+    path = export_module_json(
+        doc=self, is_standard=self.is_standard == "Yes", module=self.module
+    )
     if path:
       # py
       if not os.path.exists(path + '.py'):


### PR DESCRIPTION
The docfield `is_standard` in RenovationDashboard doctype is a `Select` field with options Yes/No
The frappe function `export_module_json` takes in a boolean for it's `is_standard` param.