### PR TITLE
fix: Duplicate User FCMs

### DIFF
--- a/renovation_core/patches.txt
+++ b/renovation_core/patches.txt
@@ -1,2 +1,3 @@
 renovation_core.patches.v1_1.detete_renovation_sms_pin_custom_field
 renovation_core.patches.v1_1.migrate_fcm_tokens_to_new_doctype
+renovation_core.patches.v1_1.delete_duplicate_fcm_tokens

--- a/renovation_core/patches/v1_1/delete_duplicate_fcm_tokens.py
+++ b/renovation_core/patches/v1_1/delete_duplicate_fcm_tokens.py
@@ -1,0 +1,22 @@
+import frappe
+
+
+def execute():
+  duplicate_tokens = frappe.db.sql("""
+  SELECT
+    token.name as token_name,
+    token.creation as token_creation,
+    token_dup.name as token_dup_name,
+    token_dup.creation as token_dup_creation
+  FROM `tabFCM User Token` token
+    INNER JOIN `tabFCM User Token` token_dup
+  ON token.token = token_dup.token
+  WHERE
+    token.name != token_dup.name
+  """, as_dict=1)
+
+  for d in duplicate_tokens:
+    if d.token_creation > d.token_dup_creation:
+      frappe.delete_doc("FCM User Token", d.token_dup_name, force=1)
+    else:
+      frappe.delete_doc("FCM User Token", d.token_name, force=1)

--- a/renovation_core/utils/fcm.py
+++ b/renovation_core/utils/fcm.py
@@ -90,21 +90,18 @@ def get_client_tokens(user=None):
 
 
 def _add_user_token(user, token, linked_sid=None):
-  _existing = frappe.get_all(
-      "FCM User Token",
-      fields=["name", "token", "user"],
-      filters={"token": token}
+  _existing = frappe.db.get_value(
+    "FCM User Token",
+    {"token": token},
+    ["name", "user"],
+    as_dict=1
   )
-  existing_user_token = None
-  for t in _existing:
-    if t.user != user:
-      frappe.delete_doc("FCM User Token", t.name, force=1, ignore_permissions=True)
+  if _existing:
+    if _existing.user != user:
+      frappe.delete_doc("FCM User Token", _existing.name, force=1, ignore_permissions=True)
     else:
-      existing_user_token = t.name
-
-  if existing_user_token:
-    frappe.db.set_value("FCM User Token", existing_user_token, "last_updated", now())
-    return frappe.get_doc("FCM User Token", existing_user_token)
+      frappe.db.set_value("FCM User Token", _existing.name, "last_updated", now())
+      return frappe.get_doc("FCM User Token", _existing.name)
 
   d = frappe.get_doc(frappe._dict(
       doctype="FCM User Token",


### PR DESCRIPTION
This will strip away FCM tokens from old users when the same token gets registered against a new user