### PR TITLE
fix: frappe-v13 jwt

### DIFF
--- a/renovation_core/__init__.py
+++ b/renovation_core/__init__.py
@@ -41,10 +41,12 @@ def on_login(login_manager):
 
 
 def on_session_creation(login_manager):
-  from .utils.auth import make_jwt
+  from .utils.auth import get_bearer_token
   if frappe.form_dict.get('use_jwt') and cint(frappe.form_dict.get('use_jwt')):
-    frappe.local.response['token'] = make_jwt(
-        login_manager.user, frappe.flags.get('jwt_expire_on'))
+    expires_in = 604800
+    frappe.local.response['token'] = get_bearer_token(
+      user=login_manager.user, expires_in=expires_in
+    )["access_token"]
     frappe.flags.jwt_clear_cookies = True
 
 

--- a/renovation_core/auth.py
+++ b/renovation_core/auth.py
@@ -57,17 +57,9 @@ class RenovationHTTPRequest(HTTPRequest):
       jwt_token = frappe.request.args.get("token")
 
     if jwt_token:
-      frappe.flags.jwt = jwt_token
-      token_info = jwt.decode(
-          jwt_token, frappe.utils.password.get_encryption_key())
-
-      # Not checking by IP since it could change on network change (Wifi -> Mobile Network)
-      # if token_info.get('ip') != frappe.local.request_ip:
-      # 	frappe.throw(frappe._("Invalide IP", frappe.AuthenticationError))
-
-      # werkzueg cookies structure is immutable
-      frappe.request.cookies = frappe._dict(frappe.request.cookies)
-      frappe.request.cookies['sid'] = token_info.get('sid')
+      headers = frappe._dict(frappe.request.headers)
+      headers["Authorization"] = f"Bearer {jwt_token}"
+      frappe.request.headers = headers
 
     # load cookies
     frappe.local.cookie_manager = CookieManagerJWT()

--- a/renovation_core/utils/auth.py
+++ b/renovation_core/utils/auth.py
@@ -4,7 +4,7 @@ import frappe
 import jwt
 from frappe import _
 from frappe.auth import LoginManager
-from frappe.utils import cint
+from frappe.utils import cint, get_url, get_datetime
 from frappe.utils.password import check_password, passlibctx, update_password
 from renovation_core.utils import update_http_response
 
@@ -59,7 +59,7 @@ def generate_otp(medium="sms", medium_id=None, sms_hash=None, purpose="login", l
   status = "success"
   if medium == "sms":
     sms_otp_template = frappe.db.get_value(
-      "System Settings", None, "sms_otp_template")
+        "System Settings", None, "sms_otp_template")
     if not sms_otp_template:
       frappe.throw("Please set SMS OTP Template in System Settings")
     sms_otp_template = frappe.get_doc("SMS Template", sms_otp_template)
@@ -69,7 +69,7 @@ def generate_otp(medium="sms", medium_id=None, sms_hash=None, purpose="login", l
         user=frappe.get_doc("User", user) if user else frappe._dict()
     )
     msg = frappe.render_template(
-            sms_otp_template.template, render_params)
+        sms_otp_template.template, render_params)
     if sms_hash:
       msg = msg + u"\n" + sms_hash
     sms = send_sms([medium_id], msg, success_msg=False)
@@ -224,12 +224,13 @@ def pin_login(user, pin, device=None):
 
 
 @frappe.whitelist(allow_guest=True)
-def get_token(user, pwd, expire_on=None, device=None):
+def get_token(user, pwd, expires_in=3600, expire_on=None, device=None):
   """
   Get the JWT Token
   :param user: The user in ctx
   :param pwd: Pwd to auth
-  :param expire_on: yyyy-mm-dd HH:mm:ss to specify the expiry
+  :param expires_in: number of seconds till expiry
+  :param expire_on: yyyy-mm-dd HH:mm:ss to specify the expiry (deprecated)
   :param device: The device in ctx
   """
   if not frappe.db.exists("User", user):
@@ -243,47 +244,84 @@ def get_token(user, pwd, expire_on=None, device=None):
   login.login_as(user)
   login.resume = False
   login.run_trigger('on_session_creation')
-  clear_sessions(user, True, device)
-  if expire_on:
-    frappe.flags.jwt_expire_on = expire_on
+
+  _expires_in = 3600
+  if cint(expires_in):
+    _expires_in = cint(expires_in)
+  elif expire_on:
+    _expires_in = (get_datetime(expire_on) - get_datetime()).total_seconds()
 
 
-def make_jwt(user, expire_on=None, secret=None):
-  if not frappe.session.get('sid') or frappe.session.sid == "Guest":
-    return
+  token = get_bearer_token(
+    user=user,
+    expires_in=_expires_in
+  )
+  frappe.local.response["token"] = token["access_token"]
+  frappe.local.response.update(token)
 
-  if frappe.session.user == frappe.session.sid:
-    # active via apikeys/bearer tokens, no real session inplace
-    from frappe.sessions import Session
-    user_info = frappe.db.get_value(
-        "User", frappe.session.user,
-        ["user_type", "first_name", "last_name"], as_dict=1)
-    frappe.local.session_obj = Session(
-        user=frappe.session.user, resume=False,
-        full_name=user_info.first_name, user_type=user_info.user_type)
-    frappe.local.session = frappe.local.session_obj.data
 
-  if not secret:
-    secret = frappe.utils.password.get_encryption_key()
-  if expire_on and not isinstance(expire_on, frappe.utils.datetime.datetime):
-    expire_on = frappe.utils.get_datetime(expire_on)
+def get_oath_client():
+  client = frappe.db.get_value("OAuth Client", {})
+  if not client:
+    # Make one auto
+    client = frappe.get_doc(frappe._dict(
+        doctype="OAuth Client",
+        app_name="default",
+        scopes="all openid",
+        redirect_urls=get_url(),
+        default_redirect_uri=get_url(),
+        grant_type="Implicit",
+        response_type="Token"
+    ))
+    client.insert(ignore_permissions=True)
+  else:
+    client = frappe.get_doc("OAuth Client", client)
 
+  return client
+
+
+def get_bearer_token(user, expires_in=3600):
+  import hashlib
+  import jwt
+  import frappe.oauth
+  from oauthlib.oauth2.rfc6749.tokens import random_token_generator, OAuth2Token
+
+  client = get_oath_client()
+  token = frappe._dict({
+      'access_token': random_token_generator(None),
+      'expires_in': expires_in,
+      'token_type': 'Bearer',
+      'scopes': client.scopes,
+      'refresh_token': random_token_generator(None)
+  })
+  bearer_token = frappe.new_doc("OAuth Bearer Token")
+  bearer_token.client = client.name
+  bearer_token.scopes = token['scopes']
+  bearer_token.access_token = token['access_token']
+  bearer_token.refresh_token = token.get('refresh_token')
+  bearer_token.expires_in = token['expires_in'] or 3600
+  bearer_token.user = user
+  bearer_token.save(ignore_permissions=True)
+  frappe.db.commit()
+
+  # ID Token
   id_token_header = {
       "typ": "jwt",
       "alg": "HS256"
   }
   id_token = {
-      "sub": user,
-      "ip": frappe.local.request_ip,
-      "sid": frappe.session.get('sid')
+      "aud": "token_client",
+      "exp": int((frappe.db.get_value("OAuth Bearer Token", token.access_token, "expiration_time") - frappe.utils.datetime.datetime(1970, 1, 1)).total_seconds()),
+      "sub": frappe.db.get_value("User Social Login", {"parent": bearer_token.user, "provider": "frappe"}, "userid"),
+      "iss": "frappe_server_url",
+      "at_hash": frappe.oauth.calculate_at_hash(token.access_token, hashlib.sha256)
   }
-  if expire_on:
-    id_token['exp'] = int(
-        (expire_on - frappe.utils.datetime.datetime(1970, 1, 1)).total_seconds())
-  token_encoded = jwt.encode(
-      id_token, secret, algorithm='HS256', headers=id_token_header).decode("ascii")
-  frappe.flags.jwt = token_encoded
-  return token_encoded
+  id_token_encoded = jwt.encode(
+      id_token, "client_secret", algorithm='HS256', headers=id_token_header)
+  id_token_encoded = frappe.safe_decode(id_token_encoded)
+  token.id_token = id_token_encoded
+  frappe.flags.jwt = id_token_encoded
+  return token
 
 
 @frappe.whitelist()
@@ -291,7 +329,9 @@ def get_jwt_token():
   """
   Get jwt token for the active user
   """
-  return make_jwt(user=frappe.session.user)
+  return get_bearer_token(
+      user=frappe.session.user, expires_in=86400
+  )["access_token"]
 
 
 @frappe.whitelist()


### PR DESCRIPTION
This PR aims to make use of the frappe's OAuth flow for auth tokens.
- Change `jwttoken` to `Bearer` in request headers (for compatibility with existing app)
- Supports SMS / PIN Logins that has `use_jwt` flag
- Updated functions that makes use of old tokens

Please check out the notion doc