### PR TITLE
fix: Handle access_token with socket.io

### DIFF
--- a/renovation_core/realtime.py
+++ b/renovation_core/realtime.py
@@ -8,14 +8,10 @@ def get_user_info(token=None, sid=None):
     if token:
         # Bearer Token
         validate_auth()
-    else:
-        # Get the user from the request
-        frappe.set_user(frappe.session.user)
-
     current_user = frappe.session.user
     data = {
         'user': current_user,
-        'sid': current_user
+        'sid': frappe.session.sid if not token else current_user
     }
 
     if data["user"] == "Guest":

--- a/socketio.js
+++ b/socketio.js
@@ -473,7 +473,7 @@ function getRenovationUserDetails(socket) {
             // Sending auth token both in header and in query param due to inconsistent behaviour observed
             // This ensures that somehow the token gets to the server and is validated for appropriate response
             headers["Authorization"] = socket.request.headers.authorization.replace("JWTToken", "Bearer");
-            query.token = getToken(socket);
+            query.token = getJwtToken(socket);
         }
 
         request.get(get_url(socket, '/api/method/renovation_core.realtime.get_user_info'))
@@ -497,11 +497,11 @@ function getRenovationUserDetails(socket) {
     });
 }
 
-function getToken(socket) {
+function getJwtToken(socket) {
     const auth = socket.request.headers.authorization;
     if (auth && typeof (auth) === "string") {
         const d = auth.split(" ");
-        if (d[0].toLowerCase().indexOf("bearer") >= 0) {
+        if (d[0].toLowerCase().indexOf("jwt") >= 0) {
             return d[1];
         }
     }

--- a/socketio.js
+++ b/socketio.js
@@ -472,7 +472,7 @@ function getRenovationUserDetails(socket) {
         if (socket.request.headers.authorization) {
             // Sending auth token both in header and in query param due to inconsistent behaviour observed
             // This ensures that somehow the token gets to the server and is validated for appropriate response
-            headers["Authorization"] = socket.request.headers.authorization;
+            headers["Authorization"] = socket.request.headers.authorization.replace("JWTToken", "Bearer");
             query.token = getJwtToken(socket);
         }
 

--- a/socketio.js
+++ b/socketio.js
@@ -473,7 +473,7 @@ function getRenovationUserDetails(socket) {
             // Sending auth token both in header and in query param due to inconsistent behaviour observed
             // This ensures that somehow the token gets to the server and is validated for appropriate response
             headers["Authorization"] = socket.request.headers.authorization.replace("JWTToken", "Bearer");
-            query.token = getJwtToken(socket);
+            query.token = getToken(socket);
         }
 
         request.get(get_url(socket, '/api/method/renovation_core.realtime.get_user_info'))
@@ -497,11 +497,11 @@ function getRenovationUserDetails(socket) {
     });
 }
 
-function getJwtToken(socket) {
+function getToken(socket) {
     const auth = socket.request.headers.authorization;
     if (auth && typeof (auth) === "string") {
         const d = auth.split(" ");
-        if (d[0].toLowerCase().indexOf("jwt") >= 0) {
+        if (d[0].toLowerCase().indexOf("bearer") >= 0) {
             return d[1];
         }
     }

--- a/socketio.js
+++ b/socketio.js
@@ -501,7 +501,7 @@ function getJwtToken(socket) {
     const auth = socket.request.headers.authorization;
     if (auth && typeof (auth) === "string") {
         const d = auth.split(" ");
-        if (d[0].toLowerCase().indexOf("jwt") >= 0) {
+        if (d[0].toLowerCase().indexOf("jwt") >= 0 || d[0].toLowerCase().indexOf("bearer") >= 0) {
             return d[1];
         }
     }


### PR DESCRIPTION
## Problem

Socket.io was failing to connect when the authorization header contained access_token. This is because of the previous implementation of JWTToken in which a JWT token was decoded to extract the user which is not the case anymore.

## Solution

The solution lies in two places:

socketio.js => Replace the authorization header type from JWTToken -> Bearer
realtime.py => Remove JWT decoding and validate using frappe's validate_auth if token is passed, otherwise set the user in frappe.session.user