### PR TITLE
fix: Check OAuth for /private files

### DIFF
--- a/renovation_core/app.py
+++ b/renovation_core/app.py
@@ -42,6 +42,8 @@ def application(request):
       response = frappe.utils.response.download_backup(request.path)
 
     elif frappe.request.path.startswith('/private/files/'):
+      from frappe.api import validate_auth
+      validate_auth()
       response = frappe.utils.response.download_private_file(request.path)
 
     elif frappe.local.request.method in ('GET', 'HEAD', 'POST'):


### PR DESCRIPTION
For private files, our way to go with jwt tokens was to have it appended in the query string:
```
https://test-site.leam.ae/api/private/files/private_file.pdf?token=< TOKEN >
```

But after our recent migration of jwt to Oauth, this failed.