### PR TITLE
fix: Workspaces

### DIFF
--- a/renovation_core/utils/sync.py
+++ b/renovation_core/utils/sync.py
@@ -7,9 +7,12 @@ def _get_doc_files(files, start_path, force=0, sync_everything=False, verbose=Fa
   """walk and sync all doctypes and pages"""
 
   # load in sequence - warning for devs
-  document_types = ['doctype', 'page', 'report', 'print_format',
-                    'website_theme', 'web_form', 'email_alert', 'print_style',
-                    'data_migration_mapping', 'data_migration_plan', 'renovation_dashboard', 'notification']
+  document_types = ['doctype', 'page', 'report', 'dashboard_chart_source', 'print_format',
+    'website_theme', 'web_form', 'web_template', 'notification', 'print_style',
+    'data_migration_mapping', 'data_migration_plan', 'workspace',
+    'onboarding_step', 'module_onboarding']
+  document_types = document_types + ['renovation_dashboard']
+
   for doctype in document_types:
     doctype_path = os.path.join(start_path, doctype)
     if os.path.exists(doctype_path):


### PR DESCRIPTION
Fixes the blank /app screen in frappe.
This function is monkey patched just for `renovation_dashboard`. I think we could sync the same via `after_migrate` hook ?