### PR TITLE
feat: Enable watermarking and thumbnails and add helper methods

### DIFF
--- a/renovation_core/hooks.py
+++ b/renovation_core/hooks.py
@@ -134,6 +134,9 @@ doc_events = {
         "on_change": "renovation_core.doc_events.system_settings.on_change",
         "before_update": "renovation_core.doc_events.system_settings.before_update"
     },
+    "File": {
+        "on_update": "renovation_core.doc_events.file.on_update"
+    },
     "Renovation Sidebar": {
         "on_change": "renovation_core.utils.renovation.clear_sidebar_cache"
     },

--- a/renovation_core/utils/images.py
+++ b/renovation_core/utils/images.py
@@ -185,3 +185,43 @@ def saveImage(im, filename, extn):
 def get_attachments(doctype, name, only_images=False, ignore_permissions=False):
   from .files import get_attachments as get_attach
   return get_attach(doctype, name, only_images, ignore_permissions)
+
+
+def get_thumbnail_url(dt, dn, df):
+  """
+  Fetches the thumbnail url (if it exists) of an image field given:
+
+  dt: `str`
+    The Doc-type it is defined on
+  dn: `str`
+    The name of Doc it is attached to
+  df: `str`
+    The field on the Doc it is attached to i.e: the "Attach" field
+  """
+  file_url = frappe.get_value(dt, dn, df)
+  if frappe.is_table(dt):
+    dt, dn = frappe.get_value(dt, dn, ("parenttype", "parent"))
+
+  attachments = get_attachments_by_docfield(dt, dn, df, file_url)
+  return attachments[0].get("thumbnail_url") if len(attachments) else None
+
+
+def get_attachments_by_docfield(dt, dn, df, file_url):
+  fields = ["thumbnail_url"]
+  filters = {"attached_to_name": dn,
+             "file_url": file_url,
+             "attached_to_doctype": dt,
+             "attached_to_field": df}
+  files = frappe.get_all(
+      "File",
+      fields=fields,
+      filters=filters)
+
+  if not files:
+    # lets try again to find the image just by looking at file_url
+    files = frappe.get_all(
+        "File",
+        fields=fields,
+        filters={"file_url": file_url,
+                 "thumbnail_url": ("!=", "")})
+  return files


### PR DESCRIPTION
This PR makes 2 changes related to "Renovation Image Settings": 
1. Adds the `on_update` File doc_event to `hooks.py`, so that  "Auto Convert Thumbnails" and "Auto apply watermarks" settings work properly as intended i.e: Every image file uploaded to the site will generate thumbnails or have watermarks applied depending on the settings selected.
2. Adds a helper method to easily retrieve the thumbnail URL of an image given information about the Doc it exists on.