### PR TITLE
fix: ignore external files when generating thumbnails

### DIFF
--- a/renovation_core/utils/images.py
+++ b/renovation_core/utils/images.py
@@ -10,7 +10,7 @@ def is_image_path(path):
     return
     
   # Skip external files
-  if not path.startswith("/"):
+  if not path.startswith(("/files/", "/private/files/")):
     return
 
   exts = ["jpg", "jpeg", "png"]


### PR DESCRIPTION
This PR serves as a fix for the issue where thumbnail generation via Renovation Image Settings would fail if external URLs were used when attaching Images to docs. 

The current fix is to detect and skip thumbnail generation on files with external URLs.