### PR TITLE
fix(Broadcast Message): Whitelist send method

### DIFF
--- a/renovation_core/renovation_core/doctype/broadcast_message/broadcast_message.py
+++ b/renovation_core/renovation_core/doctype/broadcast_message/broadcast_message.py
@@ -26,6 +26,7 @@ class BroadcastMessage(Document):
       elif t.type == "FCM Topic" and not t.fcm_topic:
         frappe.throw("FCM Topic is mandatory")
 
+  @frappe.whitelist()
   def send(self):
 
     t = frappe._dict(


### PR DESCRIPTION
### Problem

Newer versions of frappe require methods that are used by the UI using `runserverjob` to be whitelisted. Since the `send` method of Broadcast Message is not whitelisted, _Permission_ error is thrown.


### Solution

Whitelist the method for logged in users.