### PR TITLE
[PMS-T-85] fix: GQL Errors in Error Log

### DIFF
--- a/renovation_graphql/__init__.py
+++ b/renovation_graphql/__init__.py
@@ -4,6 +4,7 @@ import graphql
 from graphql import GraphQLError, parse, GraphQLSyntaxError
 
 import renovation
+from .http import get_masked_variables, get_operation_name
 
 
 async def graphql_resolver(body: dict):
@@ -13,7 +14,7 @@ async def graphql_resolver(body: dict):
     operation_name = graphql_request.operationName
     output = await execute(query, variables, operation_name)
     if len(output.get("errors", [])):
-        log_error(query, variables, operation_name, output)
+        await log_error(query, variables, operation_name, output)
         errors = []
         for err in output.errors:
             if isinstance(err, GraphQLError):
@@ -43,8 +44,11 @@ async def execute(query=None, variables=None, operation_name=None):
     return output
 
 
-def log_error(query, variables, operation_name, output):
+async def log_error(query, variables, operation_name, output):
     import traceback as tb
+    import frappe
+    from asyncer import asyncify
+
     tracebacks = []
     for idx, err in enumerate(output.errors):
         if not isinstance(err, GraphQLError):
@@ -65,6 +69,25 @@ def log_error(query, variables, operation_name, output):
     tracebacks = "\n==========================================\n".join(tracebacks)
     if renovation.local.conf.get("developer_mode"):
         print(tracebacks)
+
+    variables = get_masked_variables(query=query, variables=variables)
+    operation_name = get_operation_name(query=query, operation_name=operation_name)
+
+    error_log = frappe.new_doc("Error Log")
+    error_log.method = f"GraphQL Error: {operation_name}"
+    error_log.error = f"""
+OperationName: {operation_name}
+
+Query:
+{query}
+
+Variables:
+{variables}
+
+Traceback:
+{tracebacks}
+    """
+    await asyncify(error_log.insert)(ignore_permissions=True)
 
 
 graphql_schemas = {}

--- a/renovation_graphql/__init__.py
+++ b/renovation_graphql/__init__.py
@@ -64,11 +64,16 @@ async def log_error(query, variables, operation_name, output):
             + f"{''.join(tb.format_exception(exc, exc, exc.__traceback__))}"
         )
 
-    tracebacks.append(f"Frappe Traceback: \n{renovation.get_traceback()}")
+    frappe_traceback = renovation.get_traceback()
+    if frappe_traceback:
+        tracebacks.append(f"Frappe Traceback: \n{frappe_traceback}")
 
-    tracebacks = "\n==========================================\n".join(tracebacks)
-    if renovation.local.conf.get("developer_mode"):
-        print(tracebacks)
+    if len(tracebacks):
+        _error_info = "Traceback:\n" + "\n==========================================\n".join(tracebacks)
+        if renovation.local.conf.get("developer_mode"):
+            print(_error_info)
+    else:
+        _error_info = "Response:\n" + renovation.as_json(output)
 
     variables = get_masked_variables(query=query, variables=variables)
     operation_name = get_operation_name(query=query, operation_name=operation_name)
@@ -84,8 +89,7 @@ Query:
 Variables:
 {variables}
 
-Traceback:
-{tracebacks}
+{_error_info}
     """
     await asyncify(error_log.insert)(ignore_permissions=True)
 

--- a/renovation_graphql/http.py
+++ b/renovation_graphql/http.py
@@ -1,0 +1,77 @@
+from graphql import parse
+
+import renovation
+
+
+def get_masked_variables(query, variables):
+    """
+    Return the variables dict with password field set to "******"
+    """
+    if isinstance(variables, str):
+        variables = renovation.parse_json(variables)
+
+    variables = renovation._dict(variables)
+    try:
+        document = parse(query)
+        for operation_definition in (getattr(document, "definitions", None) or []):
+            for variable in (getattr(operation_definition, "variable_definitions", None) or []):
+                variable_name = variable.variable.name.value
+                variable_type = variable.type
+
+                if variable_name not in variables:
+                    continue
+
+                if not isinstance(variables[variable_name], str):
+                    continue
+
+                # Password! NonNull
+                if variable_type.kind == "non_null_type":
+                    variable_type = variable_type.type
+
+                # Password is a named_type
+                if variable_type.kind != "named_type" or not variable_type.name:
+                    continue
+
+                if variable_type.name.value != "Password":
+                    continue
+
+                variables[variable_name] = "*" * len(variables[variable_name])
+    except BaseException:
+        return renovation._dict(
+            status="Error Processing Variable Definitions",
+            traceback=renovation.get_traceback()
+        )
+
+    return variables
+
+
+def get_operation_name(query, operation_name):
+    """
+    Gets the active operation name
+    if operation_name is not specified in the request,
+    it will take on the first operation definition if available.
+    Otherwise returns 'unnamed-query'
+    """
+    defined_operations = []
+    try:
+        document = parse(query)
+        for operation_definition in document.definitions:
+            if operation_definition.kind != "operation_definition":
+                continue
+
+            # For non-named Queries
+            if not operation_definition.name:
+                continue
+
+            defined_operations.append(operation_definition.name.value)
+    except BaseException:
+        pass
+
+    if not operation_name and len(defined_operations):
+        return defined_operations[0]
+    elif operation_name in defined_operations:
+        return operation_name
+    elif operation_name:
+        return f"{operation_name} (invalid)"
+    else:
+        return "unnamed-query"


### PR DESCRIPTION
We do not have a frappe_app attached to renovation_graphql, so I thought why don't we take a go at `Error Log` itself

- Passwords are masked
- Operation Name are obtained from query